### PR TITLE
chore: upgrade ava

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/phuu/fetch-engine#readme",
   "devDependencies": {
-    "ava": "^0.6.1",
+    "ava": "^0.9.1",
     "tsd": "^0.6.5",
     "tslint": "^3.0.0",
     "typescript": "^1.6.2"

--- a/src/Body.test.ts
+++ b/src/Body.test.ts
@@ -7,7 +7,6 @@ test(
   "Body is requireable",
   (t: TestAssertions) => {
     t.ok(Body);
-    t.end();
   }
 );
 

--- a/src/FetchGroup.test.ts
+++ b/src/FetchGroup.test.ts
@@ -6,7 +6,6 @@ import { Mock, MockRequest, MockResponse } from "./utils/mocks";
 
 test("FetchGroup is requireable", (t: TestAssertions) => {
   t.ok(FetchGroup);
-  t.end();
 });
 
 test("FetchGroup has default plugin implementations", (t: TestAssertions) => {
@@ -35,7 +34,6 @@ test("FetchGroup has default plugin implementations", (t: TestAssertions) => {
     })
     .then((res: FetchResponse) => {
       t.is(res, mockResponse);
-      t.end();
     });
 });
 
@@ -51,7 +49,6 @@ test("shouldFetch true value is respected", (t: TestAssertions) => {
     ]
   });
   t.same(group.shouldFetch(mockReq), true);
-  t.end();
 });
 
 test("shouldFetch false value is respected", (t: TestAssertions) => {
@@ -64,7 +61,6 @@ test("shouldFetch false value is respected", (t: TestAssertions) => {
     ]
   });
   t.same(group.shouldFetch(mockReq), false);
-  t.end();
 });
 
 test(
@@ -82,7 +78,6 @@ test(
       ]
     });
     t.same(group.shouldFetch(mockReq), true);
-    t.end();
   }
 );
 
@@ -101,7 +96,6 @@ test(
       ]
     });
     t.same(group.shouldFetch(mockReq), false);
-    t.end();
   }
 );
 
@@ -123,7 +117,6 @@ test("getRequest is passed the input request", (t: TestAssertions) => {
   return group.getRequest(mockReq)
     .then((req: FetchRequest) => {
       t.same(req, mockReq);
-      t.end();
     });
 });
 
@@ -143,7 +136,6 @@ test("getRequest output is passed back", (t: TestAssertions) => {
   return group.getRequest(mockReq)
     .then((req: FetchRequest) => {
       t.same(req, newReq);
-      t.end();
     });
 });
 
@@ -173,7 +165,6 @@ test(
     return group.getRequest(mockReq)
       .then((req: FetchRequest) => {
         t.same(req, thirdReq);
-        t.end();
       });
   }
 );
@@ -193,7 +184,6 @@ test("willFetch is passed the input request", (t: TestAssertions) => {
     ]
   });
   group.willFetch(mockReq);
-  t.end();
 });
 
 test("willFetch output is ignored", (t: TestAssertions) => {
@@ -210,7 +200,6 @@ test("willFetch output is ignored", (t: TestAssertions) => {
   });
   const result = group.willFetch(mockReq);
   t.same(result, undefined);
-  t.end();
 });
 
 test(
@@ -233,7 +222,6 @@ test(
       ]
     });
     group.willFetch(mockReq);
-    t.end();
   }
 );
 
@@ -268,7 +256,6 @@ test(
     return group.fetch(mockReq, mockFetch)
       .then((res: FetchResponse) => {
         t.is(res, mockResponse);
-        t.end();
       });
   }
 );
@@ -303,7 +290,6 @@ test(
     return group.fetch(mockReq, mockFetch)
       .then((res: FetchResponse) => {
         t.is(res, mockResponse);
-        t.end();
       });
   }
 );
@@ -330,7 +316,6 @@ test(
     return group.fetch(mockReq, mockFetch)
       .then((res: FetchResponse) => {
         t.is(res, mockResponse);
-        t.end();
       });
   }
 );
@@ -357,7 +342,6 @@ test(
       promise: mockPromise,
       request: mockReq,
     });
-    t.end();
   }
 );
 
@@ -387,7 +371,6 @@ test(
       promise: mockPromise,
       request: mockReq,
     });
-    t.end();
   }
 );
 
@@ -409,7 +392,6 @@ test("getResponse is passed the input response", (t: TestAssertions) => {
   return group.getResponse(mockRes)
     .then((res: FetchResponse) => {
       t.same(res, mockRes);
-      t.end();
     });
 });
 
@@ -429,7 +411,6 @@ test("getResponse output is passed back", (t: TestAssertions) => {
   return group.getResponse(mockRes)
     .then((res: FetchResponse) => {
       t.same(res, newRes);
-      t.end();
     });
 });
 
@@ -459,7 +440,6 @@ test(
     return group.getResponse(mockRes)
       .then((req: FetchResponse) => {
         t.same(req, thirdRes);
-        t.end();
       });
   }
 );
@@ -479,7 +459,6 @@ test("didFetch is passed the input response", (t: TestAssertions) => {
     ]
   });
   group.didFetch(mockRes);
-  t.end();
 });
 
 test("didFetch output is ignored", (t: TestAssertions) => {
@@ -496,7 +475,6 @@ test("didFetch output is ignored", (t: TestAssertions) => {
   });
   const result = group.didFetch(mockRes);
   t.same(result, undefined);
-  t.end();
 });
 
 test(
@@ -519,7 +497,6 @@ test(
       ]
     });
     group.didFetch(mockRes);
-    t.end();
   }
 );
 
@@ -546,7 +523,6 @@ test("testRequest prevents shouldFetch being called", (t: TestAssertions) => {
     ]
   });
   group.shouldFetch(mockReq);
-  t.end();
 });
 
 test("testRequest prevents getRequest being called", (t: TestAssertions) => {
@@ -570,7 +546,6 @@ test("testRequest prevents getRequest being called", (t: TestAssertions) => {
     ]
   });
   group.getRequest(mockReq);
-  t.end();
 });
 
 test("testRequest prevents willFetch being called", (t: TestAssertions) => {
@@ -594,7 +569,6 @@ test("testRequest prevents willFetch being called", (t: TestAssertions) => {
     ]
   });
   group.willFetch(mockReq);
-  t.end();
 });
 
 test("testRequest prevents fetch being called", (t: TestAssertions) => {
@@ -622,7 +596,6 @@ test("testRequest prevents fetch being called", (t: TestAssertions) => {
     promise: mockPromise,
     request: mockReq,
   });
-  t.end();
 });
 
 // testResponse
@@ -648,7 +621,6 @@ test("testResponse prevents getResponse being called", (t: TestAssertions) => {
     ]
   });
   group.getResponse(mockRes);
-  t.end();
 });
 
 test("testResponse prevents didFetch being called", (t: TestAssertions) => {
@@ -672,5 +644,4 @@ test("testResponse prevents didFetch being called", (t: TestAssertions) => {
     ]
   });
   group.didFetch(mockRes);
-  t.end();
 });

--- a/src/Headers.test.ts
+++ b/src/Headers.test.ts
@@ -13,7 +13,6 @@ test(
   "Headers is requireable",
   (t: TestAssertions) => {
     t.ok(Headers);
-    t.end();
   }
 );
 
@@ -22,7 +21,6 @@ test(
   (t: TestAssertions) => {
     let headers = new Headers();
     t.ok(headers);
-    t.end();
   }
 );
 
@@ -35,7 +33,6 @@ test(
     });
     t.same(headers.get("Header-1"), "Value-1");
     t.same(headers.get("Header-2"), "Value-2");
-    t.end();
   }
 );
 
@@ -49,7 +46,6 @@ test(
     ]);
     t.same(headers.get("Header-1"), "Value-1");
     t.same(headers.get("Header-2"), "Value-2");
-    t.end();
   }
 );
 
@@ -63,7 +59,6 @@ test(
     let headers = new Headers(origHeaders);
     t.same(headers.get("Header-1"), "Value-1");
     t.same(headers.get("Header-2"), "Value-2");
-    t.end();
   }
 );
 
@@ -74,7 +69,6 @@ test(
     headers.append("Header-2", "Value-2");
     t.true(headers.has("Header-1"));
     t.true(headers.has("Header-2"));
-    t.end();
   }
 );
 
@@ -83,7 +77,6 @@ test(
   (t: TestAssertions) => {
     let headers = new ImmutableHeaders();
     t.throws(() => { headers.append("Header-2", "Value-2"); }, TypeError);
-    t.end();
   }
 );
 
@@ -95,7 +88,6 @@ test(
     headers.append("Accept-Charset", "Value-2");
     t.true(headers.has("Header-1"));
     t.false(headers.has("Accept-Charset"));
-    t.end();
   }
 );
 
@@ -107,7 +99,6 @@ test(
     headers.append("Content-Language", "Value-2");
     t.false(headers.has("Header-1"));
     t.same(headers.get("Content-Language"), "Value-2");
-    t.end();
   }
 );
 
@@ -120,7 +111,6 @@ test(
     headers.append("Content-Type", "multipart/form-data");
     t.false(headers.has("Header-1"));
     t.same(headers.getAll("Content-Type"), ["multipart/form-data"]);
-    t.end();
   }
 );
 
@@ -132,7 +122,6 @@ test(
     t.true(headers.has("Header-1"));
     headers.delete("Header-1");
     t.false(headers.has("Value-1"));
-    t.end();
   }
 );
 
@@ -142,7 +131,6 @@ test(
     let headers = new ImmutableHeaders({"Header-1": "Value-1"});
     t.true(headers.has("Header-1"));
     t.throws(() => { headers.delete("Header-1"); }, TypeError);
-    t.end();
   }
 );
 
@@ -152,7 +140,6 @@ test(
     let headers = new RequestHeaders({"Accept-Charset": "Value-1"});
     headers.delete("Accept-Charset");
     t.true(headers.has("Accept-Charset"));
-    t.end();
   }
 );
 
@@ -162,7 +149,6 @@ test(
     let headers = new RequestNoCorsHeaders({"Header-1": "Value-1"});
     headers.delete("Header-1");
     t.true(headers.has("Header-1"));
-    t.end();
   }
 );
 
@@ -172,7 +158,6 @@ test(
     let headers = new RequestNoCorsHeaders({"Accept": "Value-1"});
     headers.delete("Accept");
     t.false(headers.has("Header-1"));
-    t.end();
   }
 );
 
@@ -181,7 +166,6 @@ test(
   (t: TestAssertions) => {
     let headers = new ResponseHeaders({"Set-Cookie": "Value-1"});
     t.true(headers.has("Set-Cookie"));
-    t.end();
   }
 );
 
@@ -192,7 +176,6 @@ test(
     headers.append("Header-1", "Value-1");
     headers.append("Header-2", "Value-2");
     t.same(headers.get("Header-2"), "Value-2");
-    t.end();
   }
 );
 
@@ -204,7 +187,6 @@ test(
     headers.append("Header-2", "Value-2");
     headers.append("Header-2", "Value-3");
     t.same(headers.getAll("Header-2"), ["Value-2", "Value-3"]);
-    t.end();
   }
 );
 
@@ -214,7 +196,6 @@ test(
     let headers = new Headers();
     headers.append("Header-1", "Value-1");
     t.true(headers.has("Header-1"));
-    t.end();
   }
 );
 
@@ -224,7 +205,6 @@ test(
     let headers = new Headers();
     headers.append("Header-1", "Value-1");
     t.false(headers.has("Header-2"));
-    t.end();
   }
 );
 
@@ -236,7 +216,6 @@ test(
     t.same(headers.getAll("Header-1"), ["Value-1"]);
     headers.set("Header-1", "Value-2");
     t.same(headers.getAll("Header-1"), ["Value-2"]);
-    t.end();
   }
 );
 
@@ -249,7 +228,6 @@ test(
     t.same(headers.getAll("Header-1"), ["Value-1", "Value-2"]);
     headers.set("Header-1", "Value-2");
     t.same(headers.getAll("Header-1"), ["Value-2"]);
-    t.end();
   }
 );
 
@@ -259,7 +237,6 @@ test(
     let headers = new Headers();
     headers.set("Header-1", "Value-1");
     t.same(headers.getAll("Header-1"), ["Value-1"]);
-    t.end();
   }
 );
 
@@ -268,7 +245,6 @@ test(
   (t: TestAssertions) => {
     let headers = new ImmutableHeaders();
     t.throws(() => { headers.set("Header-2", "Value-2"); }, TypeError);
-    t.end();
   }
 );
 
@@ -281,6 +257,5 @@ test(
     };
     let headers = new Headers(h);
     t.same(headers.getHeaders(), h);
-    t.end();
   }
 );

--- a/src/Request/Request.test.ts
+++ b/src/Request/Request.test.ts
@@ -7,7 +7,6 @@ test(
   "Request is requireable",
   (t: TestAssertions) => {
     t.ok(Request);
-    t.end();
   }
 );
 
@@ -17,7 +16,6 @@ test(
     let request = new Request("brain.gif");
     t.ok(request.text);
     t.ok(request.json);
-    t.end();
   }
 );
 
@@ -26,7 +24,6 @@ test(
   (t: TestAssertions) => {
     let request = new Request("brain.gif");
     t.same(request.url, "brain.gif");
-    t.end();
   }
 );
 
@@ -43,7 +40,6 @@ test(
     t.same(newRequest.method, "GET");
     t.same(newRequest.mode, "no-cors");
     t.same(newRequest.cache, "default");
-    t.end();
   }
 );
 
@@ -153,7 +149,6 @@ test(
     /* tslint:disable:no-unused-expression */
     new Request(request);
     t.true(request.bodyUsed);
-    t.end();
   }
 );
 
@@ -166,7 +161,6 @@ test(
       },
       TypeError
     );
-    t.end();
   }
 );
 
@@ -177,6 +171,5 @@ test(
     let newRequest = request.clone();
     t.same(request.url, newRequest.url);
     t.not(request, newRequest);
-    t.end();
   }
 );

--- a/src/fetchEngine.test.ts
+++ b/src/fetchEngine.test.ts
@@ -7,7 +7,6 @@ import { Mock, MockRequest, MockResponse } from "./utils/mocks";
 
 test("fetchEngine is requireable", (t: TestAssertions) => {
   t.ok(fetchEngine);
-  t.end();
 });
 
 test("fetchEngine with no args returns a response", (t: TestAssertions) => {

--- a/src/utils/composeContinuation.test.ts
+++ b/src/utils/composeContinuation.test.ts
@@ -5,7 +5,6 @@ import composeContinuation from "./composeContinuation";
 
 test("composeContinuation is requireable", (t: TestAssertions) => {
   t.ok(composeContinuation);
-  t.end();
 });
 
 test(
@@ -16,7 +15,6 @@ test(
     const f = composeContinuation([noop, noop]);
     t.is(f(true, id), true);
     t.is(f(false, id), false);
-    t.end();
   }
 );
 
@@ -29,6 +27,5 @@ test(
     const exit = () => o;
     const f = composeContinuation([noop, exit]);
     t.is(f(true, id), o);
-    t.end();
   }
 );

--- a/src/utils/composeEvery.test.ts
+++ b/src/utils/composeEvery.test.ts
@@ -5,7 +5,6 @@ import composeEvery from "./composeEvery";
 
 test("composeEvery is requireable", (t: TestAssertions) => {
   t.ok(composeEvery);
-  t.end();
 });
 
 test(
@@ -15,7 +14,6 @@ test(
     const f = composeEvery([id, id]);
     t.is(f(true), true);
     t.is(f(false), false);
-    t.end();
   }
 );
 
@@ -32,6 +30,5 @@ test(
     t.is(composeEvery([no,  yes])(false), false);
     t.is(composeEvery([no,  no ])(true),  false);
     t.is(composeEvery([no,  no ])(false), false);
-    t.end();
   }
 );

--- a/src/utils/composePromise.test.ts
+++ b/src/utils/composePromise.test.ts
@@ -5,7 +5,6 @@ import composePromise from "./composePromise";
 
 test("composePromise is requireable", (t: TestAssertions) => {
   t.ok(composePromise);
-  t.end();
 });
 
 test(

--- a/src/utils/composeVoid.test.ts
+++ b/src/utils/composeVoid.test.ts
@@ -5,7 +5,6 @@ import composeVoid from "./composeVoid";
 
 test("composeVoid is requireable", (t: TestAssertions) => {
   t.ok(composeVoid);
-  t.end();
 });
 
 test(
@@ -20,6 +19,5 @@ test(
     const f = composeVoid([testFn, testFn]);
     const result = f(testVal);
     t.same(result, undefined);
-    t.end();
   }
 );

--- a/src/utils/getBoundImplementations.test.ts
+++ b/src/utils/getBoundImplementations.test.ts
@@ -5,7 +5,6 @@ import getBoundImplementations from "./getBoundImplementations";
 
 test("getBoundImplementations is requireable", (t: TestAssertions) => {
   t.ok(getBoundImplementations);
-  t.end();
 });
 
 test(
@@ -32,6 +31,5 @@ test(
     impls.forEach(impl => {
       impl(true);
     });
-    t.end();
   }
 );

--- a/src/utils/headers.test.ts
+++ b/src/utils/headers.test.ts
@@ -16,7 +16,6 @@ test(
     t.ok(isForbiddenResponseHeaderName);
     t.ok(isSimpleHeader);
     t.ok(getNormalizedHeaderName);
-    t.end();
   }
 );
 
@@ -24,7 +23,6 @@ test(
   "getNormalizedHeaderName() strips all whitespace types",
   (t: TestAssertions) => {
     t.same(getNormalizedHeaderName("\r\t\n header-name\r\t \n"), "header-name");
-    t.end();
   }
 );
 
@@ -32,7 +30,6 @@ test(
   "getNormalizedHeaderName() lowercases characters",
   (t: TestAssertions) => {
     t.same(getNormalizedHeaderName("Header-Name"), "header-name");
-    t.end();
   }
 );
 
@@ -40,7 +37,6 @@ test(
   "isForbiddenHeaderName() returns true if forbidden",
   (t: TestAssertions) => {
     t.true(isForbiddenHeaderName("Content-Length"));
-    t.end();
   }
 );
 
@@ -48,7 +44,6 @@ test(
   "isForbiddenHeaderName() returns false if allowed",
   (t: TestAssertions) => {
     t.false(isForbiddenHeaderName("Not-Forbidden"));
-    t.end();
   }
 );
 
@@ -56,7 +51,6 @@ test(
   "isForbiddenResponseHeaderName() returns true if forbidden",
   (t: TestAssertions) => {
     t.true(isForbiddenResponseHeaderName("Set-Cookie"));
-    t.end();
   }
 );
 
@@ -64,7 +58,6 @@ test(
   "isForbiddenResponseHeaderName() returns false if allowed",
   (t: TestAssertions) => {
     t.false(isForbiddenResponseHeaderName("Not-Forbidden"));
-    t.end();
   }
 );
 
@@ -72,7 +65,6 @@ test(
   "isSimpleHeader() returns true if simple header name",
   (t: TestAssertions) => {
     t.true(isSimpleHeader("Content-Type"));
-    t.end();
   }
 );
 
@@ -80,7 +72,6 @@ test(
   "isSimpleHeader() returns true if valid name/value combination",
   (t: TestAssertions) => {
     t.true(isSimpleHeader("Content-Type", "text/plain"));
-    t.end();
   }
 );
 
@@ -88,7 +79,6 @@ test(
   "isSimpleHeader() returns false if not simple header name",
   (t: TestAssertions) => {
     t.false(isSimpleHeader("Not-Simple"));
-    t.end();
   }
 );
 
@@ -96,6 +86,5 @@ test(
   "isSimpleHeader() returns false if invalid name/value combination",
   (t: TestAssertions) => {
     t.false(isSimpleHeader("Content-Type", "not/allowed-mime"));
-    t.end();
   }
 );

--- a/src/utils/sideEffect.test.ts
+++ b/src/utils/sideEffect.test.ts
@@ -5,7 +5,6 @@ import sideEffect from "./sideEffect";
 
 test("sideEffect is requireable", (t: TestAssertions) => {
   t.ok(sideEffect);
-  t.end();
 });
 
 test(
@@ -16,7 +15,6 @@ test(
     const f = sideEffect(id);
     t.is(f(true), true);
     t.is(f(false), false);
-    t.end();
   }
 );
 
@@ -29,7 +27,6 @@ test(
       return false;
     };
     sideEffect(inner)(true);
-    t.end();
   }
 );
 
@@ -42,7 +39,6 @@ test(
       t.same(y, false);
     };
     sideEffect(inner)(true, false);
-    t.end();
   }
 );
 
@@ -52,6 +48,5 @@ test(
     t.plan(1);
     const result = sideEffect(_ => false)(true);
     t.same(result, true);
-    t.end();
   }
 );


### PR DESCRIPTION
Required removing all the `t.end()` calls.

:rocket: 