### PR TITLE
feat: plugin getX optional promise

### DIFF
--- a/src/.d.ts
+++ b/src/.d.ts
@@ -64,12 +64,12 @@ declare interface FetchFetchingArgs {
 declare interface FetchEnginePlugin {
   // pre-fetch
   shouldFetch?: (req: FetchRequest) => boolean;
-  getRequest?: (req: FetchRequest) => Promise<FetchRequest>;
+  getRequest?: (req: FetchRequest) => Promise<FetchRequest>|FetchRequest;
   willFetch?: (req: FetchRequest) => void;
   // fetch
   fetching?: (args: FetchFetchingArgs) => void;
   // post-fetch
-  getResponse?: (req: FetchResponse) => Promise<FetchResponse>;
+  getResponse?: (req: FetchResponse) => Promise<FetchResponse>|FetchResponse;
   didFetch?: (req: FetchResponse) => void;
 }
 

--- a/src/utils/composePromise.ts
+++ b/src/utils/composePromise.ts
@@ -9,7 +9,7 @@ export default function composePromise<T>(
       next: Fn,
       f: Fn
     ): Fn => (
-      (v: T): Promise<T> => f(v).then(next)
+      (v: T): Promise<T> => Promise.resolve(v).then(f).then(next)
     ),
     (v: T): Promise<T> => Promise.resolve(v)
   );


### PR DESCRIPTION
Allows a plugin's getRequest and getResponse methods to return a Promise or a
plain value.

Close #34.